### PR TITLE
fix: paginate getting the list of accounts in an OU

### DIFF
--- a/fetch-account-details.py
+++ b/fetch-account-details.py
@@ -87,14 +87,16 @@ def get_home_region():
 
 def get_accounts_ou(ou_id):
     '''List of accounts in an organizational unit'''
-    accounts = []
-    results = []
+    accounts = list()
     try:
-        results = ORG.list_accounts_for_parent(ParentId=ou_id)['Accounts']
+        accounts_paginator = ORG.get_paginator("list_accounts_for_parent")
+        accounts_iterator = accounts_paginator.paginate(ParentId=ou_id)
     except ClientError as exe:
-        error_and_exit('Unable to get Accounts list: ' + str(exe))
-    for result in results:
-        accounts.append(result['Id'])
+        LOGGER.error("Unable to get Accounts list: " + str(exe))
+    for page in accounts_iterator:
+        for account_info in page["Accounts"]:
+            if account_info["Id"]:
+                accounts.append(account_info["Id"])
     return accounts
 
 def does_ou_exists(ou_object):

--- a/prepare-ou.py
+++ b/prepare-ou.py
@@ -104,15 +104,16 @@ def get_required_data():
 
 def get_accounts_ou(ou_id):
     '''List of accounts in an organizational unit'''
-    accounts = []
-    results = []
+    accounts = list()
     try:
-        results = ORG.list_accounts_for_parent(ParentId=ou_id)['Accounts']
+        accounts_paginator = ORG.get_paginator("list_accounts_for_parent")
+        accounts_iterator = accounts_paginator.paginate(ParentId=ou_id)
     except ClientError as exe:
-        LOGGER.error('Unable to get Accounts list: ' + str(exe))
-    for result in results:
-        if result['Id'] :
-            accounts.append(result['Id'])
+        LOGGER.error("Unable to get Accounts list: " + str(exe))
+    for page in accounts_iterator:
+        for account_info in page["Accounts"]:
+            if account_info["Id"]:
+                accounts.append(account_info["Id"])
     return accounts
 
 def assume_role(account):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This paginates the call to get all of the accounts in an OU. This is necessary because the call limits the number of accounts returned to 20 without pagination


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
